### PR TITLE
Fix Makefile to run on macOS

### DIFF
--- a/keyboard_creator/Makefile
+++ b/keyboard_creator/Makefile
@@ -76,13 +76,13 @@ create:
 addsymlib%:
 	@$(MAKE) -s addsubmodule:${ARG1} ; \
 	echo -e "$(BOLD) >> Adding ${ARG1} symbol library to KiCAD library table... \c" ; \
-	sed -i "2 i (lib (name \"${ARG1}\")(type \"KiCad\")(uri \"$$\{KIPRJMOD\}/${LIBDIR}/${ARG1}/${ARG1}.kicad_sym\")(options \"\")(descr \"Acheron Project symbol library\")) " ${KICADDIR}/sym-lib-table > /dev/null ; \
+	perl -pi -e 'print "(lib (name \"${ARG1}\")(type \"KiCad\")(uri \"\$${KIPRJMOD}/${LIBDIR}/${ARG1}/${ARG1}.kicad_sym\")(options \"\")(descr \"Acheron Project symbol library\"))\n" if $$. == 2' ${KICADDIR}/sym-lib-table ; \
 	echo "$(BOLD)$(GREEN)Done.$(RESET)"
 
 addfootprintlib%:
 	@$(MAKE) -s addsubmodule:${ARG1}.pretty ; \
 	echo -e "$(BOLD) >> Adding ${ARG1} footprint library to KiCAD library table... \c" ; \
-	sed -i "2 i (lib (name \"${ARG1}\")(type \"KiCad\")(uri \"$$\{KIPRJMOD\}/${LIBDIR}/${ARG1}.pretty\")(options \"\")(descr \"Acheron Project footprint library\")) " ${KICADDIR}/fp-lib-table > /dev/null ; \
+	perl -pi -e 'print "(lib (name \"${ARG1}\")(type \"KiCad\")(uri \"\$${KIPRJMOD}/${LIBDIR}/${ARG1}.pretty\")(options \"\")(descr \"Acheron Project footprint library\"))\n" if $$. == 2' ${KICADDIR}/fp-lib-table > /dev/null ; \
 	echo "$(BOLD)$(GREEN)Done.$(RESET)"
 	
 # check:libdir checks if the KICADDIR/LIBDIR exists. If not, creates it with the parent KICADDIR if it doesnt exist.


### PR DESCRIPTION
I attempted to run the setup script on my mac machine and ran into errors with the `sed` command. It turns out that the built in macOS version is BSD based and some of the args function differently between it and the GNU version. I searched around and it seemed like changing the [sed args](https://stackoverflow.com/a/4247319) around could get it working on mac, but might break the command for linux systems. There was also recommendations for installing the GNU version using homebrew, but I figured that wouldn't be a good idea for something like this that is supposed to be beginner friendly.

I've switched the script over to using perl, which seems to come pre-installed on most systems and was able to run the command in macOS. Unfortunately I don't currently have any kind of linux environment set up so I couldn't test it there. However I was able to test that it worked before and after my changes in the MSYS2 environment on my windows machine.

Output pre-fix on my mac machine:
<img width="1320" alt="Screen Shot 2021-10-11 at 5 43 46 PM" src="https://user-images.githubusercontent.com/4492969/136871857-7bf36068-d24d-47a0-abf3-730d76be5c94.png">
<img width="418" alt="Screen Shot 2021-10-11 at 5 46 15 PM" src="https://user-images.githubusercontent.com/4492969/136871864-3a476ce8-3f60-43ff-94e8-62892542cf6d.png">

Output post-fix on my mac machine:
<img width="1325" alt="Screen Shot 2021-10-11 at 5 44 42 PM" src="https://user-images.githubusercontent.com/4492969/136871860-fdc1868b-7d5d-434e-9379-e6c3e05ba870.png">
<img width="1285" alt="Screen Shot 2021-10-11 at 5 45 18 PM" src="https://user-images.githubusercontent.com/4492969/136871861-13219973-4a2c-46b0-93ab-9cfbd307d390.png">

I am far from an expert on Makefile/Bash scripts so there may be better fixes, but this is what I was able to get working.