### PR TITLE
Minor improvements for the sed command

### DIFF
--- a/keyboard_creator/keyboard_create.sh
+++ b/keyboard_creator/keyboard_create.sh
@@ -317,7 +317,7 @@ add_symlib() {
 	if [[ ${rc} -ne 0 ]]; then
 		echo2stdout -e "${BOLD}>> Adding ${MAGENTA}${SYMBOLS_LIBRARY}${WHITE} symbol library to KiCAD library table... \c"
 		${SED_COMMAND} -i${SED_BACKUP_EXT} -e "2i\\
-(lib (name \"${SYMBOLS_LIBRARY}\")(type \"KiCad\")(uri \"\\\$\{KIPRJMOD\}\/${LIBDIR}/${SYMBOLS_LIBRARY}/${SYMBOLS_LIBRARY}.kicad_sym\")(options \"\")(descr \"Acheron Project symbol library\"))
+(lib (name \"${SYMBOLS_LIBRARY}\")(type \"KiCad\")(uri \"\${KIPRJMOD}/${LIBDIR}/${SYMBOLS_LIBRARY}/${SYMBOLS_LIBRARY}.kicad_sym\")(options \"\")(descr \"Acheron Project symbol library\"))
 " "${KICADDIR}/sym-lib-table" > /dev/null
 		${TRASH_COMMAND} "${KICADDIR}/sym-lib-table${SED_BACKUP_EXT}"
 		echo2stdout "${BOLD}${GREEN}Done.${RESET}"
@@ -337,7 +337,7 @@ add_footprintlib(){
 	if [[ ${rc} -ne 0 ]]; then
 		echo2stdout -e "${BOLD}>> Adding ${MAGENTA}${FOOTPRINTS_LIBRARY}${WHITE} footprint library to KiCAD library table... \c"
 		${SED_COMMAND} -i${SED_BACKUP_EXT} -e "2i\\
-(lib (name \"${FOOTPRINTS_LIBRARY}\")(type \"KiCad\")(uri \"\\\$\{KIPRJMOD\}/${LIBDIR}/${FOOTPRINTS_LIBRARY}.pretty\")(options \"\")(descr \"Acheron Project footprint library\"))
+(lib (name \"${FOOTPRINTS_LIBRARY}\")(type \"KiCad\")(uri \"\${KIPRJMOD}/${LIBDIR}/${FOOTPRINTS_LIBRARY}.pretty\")(options \"\")(descr \"Acheron Project footprint library\"))
 " "${KICADDIR}/fp-lib-table" > /dev/null
 		${TRASH_COMMAND} "${KICADDIR}/fp-lib-table${SED_BACKUP_EXT}"
 		echo2stdout "${BOLD}${GREEN}Done.${RESET}"

--- a/keyboard_creator/keyboard_create.sh
+++ b/keyboard_creator/keyboard_create.sh
@@ -47,7 +47,7 @@ TEMPLATE='BLANK'
 function echo_text() {
 	local text_to_print="${*:$#}"  # Assuming it's the last parameter
 	local echo_args="${*%"${!#}"}" # Assuming it's the rest
-	echo ${echo_args} "${text_to_print}" >&1
+	echo ${echo_args} "${text_to_print}"
 }
 
 function echo2stdout() {

--- a/keyboard_creator/keyboard_create.sh
+++ b/keyboard_creator/keyboard_create.sh
@@ -28,6 +28,7 @@ readonly KICADDIR='kicad_files'
 readonly ACRNPRJ_REPO='git@github.com:AcheronProject'
 readonly ALLOWED_SWITCHTYPES=(MX MX_soldermask MXA MXH)
 readonly ALLOWED_TEMPLATES=(BLANK J48 J64)
+readonly SED_BACKUP_EXT='.bak'
 
 VERBOSE=0
 NOGRAPHICS=0
@@ -315,9 +316,10 @@ add_symlib() {
 
 	if [[ ${rc} -ne 0 ]]; then
 		echo2stdout -e "${BOLD}>> Adding ${MAGENTA}${SYMBOLS_LIBRARY}${WHITE} symbol library to KiCAD library table... \c"
-		${SED_COMMAND} -i'' -e "2i\\
+		${SED_COMMAND} -i${SED_BACKUP_EXT} -e "2i\\
 (lib (name \"${SYMBOLS_LIBRARY}\")(type \"KiCad\")(uri \"\\\$\{KIPRJMOD\}\/${LIBDIR}/${SYMBOLS_LIBRARY}/${SYMBOLS_LIBRARY}.kicad_sym\")(options \"\")(descr \"Acheron Project symbol library\"))
 " "${KICADDIR}/sym-lib-table" > /dev/null
+		${TRASH_COMMAND} "${KICADDIR}/sym-lib-table${SED_BACKUP_EXT}"
 		echo2stdout "${BOLD}${GREEN}Done.${RESET}"
 	fi
 
@@ -334,9 +336,10 @@ add_footprintlib(){
 
 	if [[ ${rc} -ne 0 ]]; then
 		echo2stdout -e "${BOLD}>> Adding ${MAGENTA}${FOOTPRINTS_LIBRARY}${WHITE} footprint library to KiCAD library table... \c"
-		${SED_COMMAND} -i'' -e "2i\\
+		${SED_COMMAND} -i${SED_BACKUP_EXT} -e "2i\\
 (lib (name \"${FOOTPRINTS_LIBRARY}\")(type \"KiCad\")(uri \"\\\$\{KIPRJMOD\}/${LIBDIR}/${FOOTPRINTS_LIBRARY}.pretty\")(options \"\")(descr \"Acheron Project footprint library\"))
 " "${KICADDIR}/fp-lib-table" > /dev/null
+		${TRASH_COMMAND} "${KICADDIR}/fp-lib-table${SED_BACKUP_EXT}"
 		echo2stdout "${BOLD}${GREEN}Done.${RESET}"
 	fi
 

--- a/keyboard_creator/keyboard_create.sh
+++ b/keyboard_creator/keyboard_create.sh
@@ -351,7 +351,7 @@ add_footprintlib(){
 # This function deletes all *.git files and folders, also the ${KICADDIR}.
 clean(){
 	echo2stdout -e "${YELLOW}${BOLD}>> CLEANING${WHITE} produced files... \c"
-	${TRASH_COMMAND} .git .gitmodules "${KICADDIR}" > /dev/null 2>&1
+	${TRASH_COMMAND} ./.git ./.gitmodules ./"${KICADDIR}" > /dev/null 2>&1
 	echo2stdout -e "${BOLD}${GREEN}Done.${RESET}"
 }
 #}}}1
@@ -404,7 +404,7 @@ main(){
 
 	if [[ "${LOCAL_CLEANCREATE}" -eq 1 ]]; then
 		echo2stdout -e "${BOLD}${YELLOW}>>${WHITE} Cleaning up... ${RESET}\c"
-		${TRASH_COMMAND} keyboard_create.sh *_template
+		${TRASH_COMMAND} ./keyboard_create.sh ./*_template > /dev/null 2>&1
 		echo2stdout "${BOLD}${GREEN} Done.${RESET}"
 	fi
 


### PR DESCRIPTION
I saw that you merged the other PR so here I am opening a new one 😄 

So what I didn't notice at first is that for macOS, the script creates additional files `sym-lib-table-e` and `fp-lib-table-e` due to the `-i'' -e` options given to sed because it evaluates `-i'' -e` to `-i -e` so it thinks that the backup extension file should be `-e` 😞 

After trying a lot of solutions to make the `sed` command portable across Linux and macOS, I think that the best thing would be to explicitly specify a backup file extension and then delete it using the `${TRASH_COMMAND}`.
Other options are also available like using `perl` or `awk` for example.

Regarding the `gio` command, while it comes preinstalled on almost all the Linux distros, I happened to use some systems where it wasn't available out of the box.

Also, I don't think that's possible to trash files/directories using `gio` on bind-mounted filesystems on Linux.