### PR TITLE
Script improvements and bug fixes

### DIFF
--- a/keyboard_creator/keyboard_create.sh
+++ b/keyboard_creator/keyboard_create.sh
@@ -150,8 +150,9 @@ kicad_setup() {
 }
 #}}}1
 
-# git "add" functions ----------------------- {{{1
-# The git_add_library function does exactly that: adds a library to the project. However, this can be done in two ways: either as a git submodule or simply cloning the library from its repository; the behavior depends on the NO_GIT_SUBMODULES flag set when the script is called. The other function, add_symlib and add_footprint lib, are based on add_submodule. What they do, adittionally to adding a symbol or footprint library submodule, is also adding that library to KiCAD's library tables "sym-lib-table" and "fp-lib-table" throught the sed command. It must be noted that these two files should not be created from scratch as they have a header and a footer; hence, the template folders contain unedited, blank version of these files.
+# git_add_library function ----------------------- {{{1
+# The git_add_library function does exactly that: adds a library to the project from a git repository.
+# However, this can be done in two ways: either as a git submodule or simply cloning the library from its repository; the behavior depends on the NO_GIT_SUBMODULES flag set when the script is called.
 git_add_library() {
 	local TARGET_LIBRARY="$1"
 	local NO_GIT_SUBMODULES="$2"
@@ -185,7 +186,10 @@ git_add_library() {
 	echo2stdout "${BOLD}${GREEN}Done.${RESET}"
 	return 1
 }
+#}}}1
 
+# add_line_in_file function ----------------------- {{{1
+# This function inserts a line in a file at a specific line number using a Perl command
 add_line_in_file() {
 	local LINE="$1"
 	local TARGET_FILE="$2"
@@ -202,7 +206,11 @@ add_line_in_file() {
 
 	return 1
 }
+#}}}1
 
+# add_library function ----------------------- {{{1
+# This function calls the git_add_library and add_line_in_file functions. First, it adds the library from the the git repository, then depending on the IS_FOOTPRINT variable, it adds the library to KiCAD's library tables "sym-lib-table" and "fp-lib-table".
+# It must be noted that these two files should not be created from scratch as they have a header and a footer; hence, the template folders contain unedited, blank version of these files.
 add_library() {
 	local LIBRARY="$1"
 	local NO_GIT_SUBMODULES="$2"

--- a/keyboard_creator/keyboard_create.sh
+++ b/keyboard_creator/keyboard_create.sh
@@ -165,7 +165,7 @@ add_git_library() {
 		return 0
 	fi
 
-	 if [[ "${NO_GIT_SUBMODULES}" -eq 0 ]]; then
+	if [[ "${NO_GIT_SUBMODULES}" -eq 0 ]]; then
 		echo2stdout -e "${BOLD}>> Adding ${MAGENTA}${TARGET_LIBRARY}${WHITE} library as a submodule from ${BLUE}${BOLD}${TARGET_LIBRARY_GIT_REPO_URL}${RESET} at ${RED}${BOLD}\"${KICADDIR}/${LIBDIR}/${TARGET_LIBRARY}\"${RESET} folder... \c"
 		eval "${GIT_COMMAND}" submodule add "${TARGET_LIBRARY_GIT_REPO_URL}" "${KICADDIR}/${LIBDIR}/${TARGET_LIBRARY}" "${OUTPUT_REDIRECTION}"
 		exit_code=$?

--- a/keyboard_creator/keyboard_create.sh
+++ b/keyboard_creator/keyboard_create.sh
@@ -4,14 +4,14 @@
 
 # ANSI terminal colors (see 'man tput') ----- {{{1
 # See 'man tput' and https://linuxtidbits.wordpress.com/2008/08/11/output-color-on-bash-scripts/. Don't use color if there isn't a $TERM environment variable.
-readonly BOLD=$(tput bold)
-readonly RED=$(tput setaf 1)
-readonly GREEN=$(tput setaf 2)
-readonly YELLOW=$(tput setaf 3)
-readonly BLUE=$(tput setaf 4)
-readonly MAGENTA=$(tput setaf 5)
-readonly WHITE=$(tput setaf 7)
-readonly RESET=$(tput sgr0)
+BOLD=$(tput bold); readonly BOLD
+RED=$(tput setaf 1); readonly RED
+GREEN=$(tput setaf 2); readonly GREEN
+YELLOW=$(tput setaf 3); readonly YELLOW
+BLUE=$(tput setaf 4); readonly BLUE
+MAGENTA=$(tput setaf 5); readonly MAGENTA
+WHITE=$(tput setaf 7); readonly WHITE
+RESET=$(tput sgr0); readonly RESET
 #}}}1
 
 # Default commands ------------------------------------------------------------------------- {{{1

--- a/keyboard_creator/keyboard_create.sh
+++ b/keyboard_creator/keyboard_create.sh
@@ -317,7 +317,7 @@ add_symlib() {
 	if [[ ${rc} -ne 0 ]]; then
 		echo2stdout -e "${BOLD}>> Adding ${MAGENTA}${SYMBOLS_LIBRARY}${WHITE} symbol library to KiCAD library table... \c"
 		${SED_COMMAND} -i${SED_BACKUP_EXT} -e "2i\\
-(lib (name \"${SYMBOLS_LIBRARY}\")(type \"KiCad\")(uri \"\\\$\{KIPRJMOD\}\/${LIBDIR}/${SYMBOLS_LIBRARY}/${SYMBOLS_LIBRARY}.kicad_sym\")(options \"\")(descr \"Acheron Project symbol library\"))
+(lib (name \"${SYMBOLS_LIBRARY}\")(type \"KiCad\")(uri \"\${KIPRJMOD}/${LIBDIR}/${SYMBOLS_LIBRARY}/${SYMBOLS_LIBRARY}.kicad_sym\")(options \"\")(descr \"Acheron Project symbol library\"))
 " "${KICADDIR}/sym-lib-table" > /dev/null
 		${TRASH_COMMAND} "${KICADDIR}/sym-lib-table${SED_BACKUP_EXT}"
 		echo2stdout "${BOLD}${GREEN}Done.${RESET}"
@@ -337,7 +337,7 @@ add_footprintlib(){
 	if [[ ${rc} -ne 0 ]]; then
 		echo2stdout -e "${BOLD}>> Adding ${MAGENTA}${FOOTPRINTS_LIBRARY}${WHITE} footprint library to KiCAD library table... \c"
 		${SED_COMMAND} -i${SED_BACKUP_EXT} -e "2i\\
-(lib (name \"${FOOTPRINTS_LIBRARY}\")(type \"KiCad\")(uri \"\\\$\{KIPRJMOD\}/${LIBDIR}/${FOOTPRINTS_LIBRARY}.pretty\")(options \"\")(descr \"Acheron Project footprint library\"))
+(lib (name \"${FOOTPRINTS_LIBRARY}\")(type \"KiCad\")(uri \"\${KIPRJMOD}/${LIBDIR}/${FOOTPRINTS_LIBRARY}.pretty\")(options \"\")(descr \"Acheron Project footprint library\"))
 " "${KICADDIR}/fp-lib-table" > /dev/null
 		${TRASH_COMMAND} "${KICADDIR}/fp-lib-table${SED_BACKUP_EXT}"
 		echo2stdout "${BOLD}${GREEN}Done.${RESET}"

--- a/keyboard_creator/keyboard_create.sh
+++ b/keyboard_creator/keyboard_create.sh
@@ -45,9 +45,9 @@ TEMPLATE='BLANK'
 
 # Printing functions ----------------------------------------------------------------------------- {{{1
 function echo_text() {
-	local text_to_print="${*:$#}"  # Assuming it's the last parameter
-	local echo_args="${*%"${!#}"}" # Assuming it's the rest
-	echo ${echo_args} "${text_to_print}"
+	local TEXT_TO_PRINT="${*:$#}"  # Assuming it's the last parameter
+	local ECHO_ARGS="${*%"${!#}"}" # Assuming it's the rest
+	echo ${ECHO_ARGS} "${TEXT_TO_PRINT}"
 }
 
 function echo2stdout() {
@@ -98,136 +98,6 @@ ${GREEN}>>${BOLD}${WHITE} Arguments:${RESET}
 ${RESET}"
 }
 # }}}1
-
-# Parsing options and arguments --------------------------------------------------------------- {{{1
-while (( "$#" )); do
-	case $1 in
-	# HANDLING ARGUMENTS ---------------------
-		-h | --help)
-			usage
-			exit 0
-			;;
-		-v | --verbose)
-			VERBOSE=1
-			OUTPUT_REDIRECTION=
-			;;
-		-cc | --cleancreate)
-			CLEANCREATE=1
-			;;
-		-nl | --nologos)
-			NOLOGOS=1
-			;;
-		-ng | --nographics)
-			NOGRAPHICS=1
-			;;
-		-n3 | --no3d)
-			NO3D=1
-			;;
-		-nr | --norepo)
-			NO_GIT_REPO=1
-			;;
-		-ns | --nosubmodule)
-			NO_GIT_SUBMODULES=1
-			;;
-		-pc | --purgeclean)
-			PURGECLEAN=1
-			;;
-	# HANDLING OPTIONS -----------------------
-		# TEMPLATE ARGUMENT --------------
-		-t | --template)
-			TEMPLATE="$2"
-			shift
-			;;
-		--template=?*)
-			TEMPLATE=${1#*=} # Deletes everything up to "=" and assigns the remainder
-			;;
-		# KICADDIR ARGUMENT --------------
-		-kd | --kicaddir)
-			KICADDIR="$2"
-			shift
-			;;
-		--kicaddir=?*)
-			KICADDIR=${1#*=} # Deletes everything up to "=" and assigns the remainder
-			;;
-		# LIBDIR ARGUMENT ----------------
-		-ld | --libdir)
-			LIBDIR="$2"
-			shift
-			;;
-		--libdir=?*)
-			LIBDIR=${1#*=} # Deletes everything up to "=" and assigns the remainder
-			;;
-		# PRJNAME ARGUMENT ----------------
-		-p | --projectname)
-			PRJNAME="$2"
-			shift
-			;;
-		--projectname=?*)
-			PRJNAME=${1#*=} # Deletes everything up to "=" and assigns the remainder
-			;;
-		# SWITCHTYPE ARGUMENT ----------------
-		-s | --switchtype)
-			SWITCHTYPE="$2"
-			shift
-			;;
-		--switchtype=?*)
-			SWITCHTYPE=${1#*=} # Deletes everything up to "=" and assigns the remainder
-			;;
-		*)
-			echo2stderr "${BOLD}${RED}>> WARN: ${RESET} Unknown argument '$1'. Ignoring..."
-	esac
-	shift
-done
-#}}}1
-
-# Check the correctness of the values read from stdin ----------------------------------------- {{{1
-verbose_logging "${BOLD}>> INFO:  ${GREEN}Verbose logging enabled${RESET}"
-verbose_logging "${BOLD}>> DEBUG: ${YELLOW}OUTPUT_REDIRECTION set to ${OUTPUT_REDIRECTION}${RESET}"
-verbose_logging "${BOLD}>> DEBUG: ${YELLOW}CLEANCREATE set to ${CLEANCREATE}${RESET}"
-verbose_logging "${BOLD}>> DEBUG: ${YELLOW}NOLOGOS set to ${NOLOGOS}${RESET}"
-verbose_logging "${BOLD}>> DEBUG: ${YELLOW}NOGRAPHICS set to ${NOGRAPHICS}${RESET}"
-verbose_logging "${BOLD}>> DEBUG: ${YELLOW}NO3D set to ${NO3D}${RESET}"
-verbose_logging "${BOLD}>> DEBUG: ${YELLOW}NO_GIT_REPO set to ${NO_GIT_REPO}${RESET}"
-verbose_logging "${BOLD}>> DEBUG: ${YELLOW}NO_GIT_SUBMODULES set to ${NO_GIT_SUBMODULES}${RESET}"
-verbose_logging "${BOLD}>> DEBUG: ${YELLOW}PURGECLEAN set to ${PURGECLEAN}${RESET}"
-verbose_logging "${BOLD}>> DEBUG: ${YELLOW}TEMPLATE set to ${TEMPLATE}${RESET}"
-verbose_logging "${BOLD}>> DEBUG: ${YELLOW}KICADDIR set to ${KICADDIR}${RESET}"
-verbose_logging "${BOLD}>> DEBUG: ${YELLOW}LIBDIR set to ${LIBDIR}${RESET}"
-verbose_logging "${BOLD}>> DEBUG: ${YELLOW}PRJNAME set to ${PRJNAME}${RESET}"
-verbose_logging "${BOLD}>> DEBUG: ${YELLOW}SWITCHTYPE set to ${SWITCHTYPE}${RESET}"
-
-if [[ -z "${TEMPLATE}" ]]; then
-	echo2stderr "${BOLD}${RED}>> ERROR:${RESET} -t/--template argument requires a non-empty string."
-	exit 1
-fi
-
-if [[ -z "${KICADDIR}" ]]; then
-	echo2stderr "${BOLD}${RED}>> ERROR:${RESET} -kd/--kicaddir argument requires a non-empty string."
-	exit 2
-fi
-
-if [[ -z "${LIBDIR}" ]]; then
-	echo2stderr "${BOLD}${RED}>> ERROR:${RESET} -ld/--libdir argument requires a non-empty string."
-	exit 3
-fi
-
-if [[ -z "${PRJNAME}" ]]; then
-	echo2stderr "${BOLD}${RED}>> ERROR:${RESET} -p/--projectname requires a non-empty string."
-	exit 4
-fi
-#}}}1
-
-# Checking if the limited options are in the allowed values ----------------------------------- {{{1
-if [[ ! ${ALLOWED_SWITCHTYPES[*]} =~ (^|[[:space:]])"${SWITCHTYPE}"($|[[:space:]]) ]]; then
-	echo2stderr "${BOLD}${RED}>> ERROR:${WHITE} switch type option '${SWITCHTYPE}' is not recognized. Run the script with the '-h' option for usage guidelines.${RESET}"
-	exit 5
-fi
-
-if [[ ! ${ALLOWED_TEMPLATES[*]} =~ (^|[[:space:]])"${TEMPLATE}"($|[[:space:]]) ]]; then
-	echo2stderr "${BOLD}${RED}>> ERROR:${WHITE} template option '${TEMPLATE}' is not recognized. Run the script with the '-h' option for usage guidelines.${RESET}"
-	exit 6
-fi
-#}}}1
 
 # kicad_setup function ---------------------- {{{1
 # kicad_setup is a function that checks if kicaddir exists; if not, creates it; then copies the files in joker_template to kicaddir and adds symbol and footprint library tables.
@@ -435,6 +305,136 @@ main(){
 
 	exit 0
 }
+#}}}1
+
+# Parsing options and arguments --------------------------------------------------------------- {{{1
+while (( "$#" )); do
+	case $1 in
+	# HANDLING ARGUMENTS ---------------------
+		-h | --help)
+			usage
+			exit 0
+			;;
+		-v | --verbose)
+			VERBOSE=1
+			OUTPUT_REDIRECTION=
+			;;
+		-cc | --cleancreate)
+			CLEANCREATE=1
+			;;
+		-nl | --nologos)
+			NOLOGOS=1
+			;;
+		-ng | --nographics)
+			NOGRAPHICS=1
+			;;
+		-n3 | --no3d)
+			NO3D=1
+			;;
+		-nr | --norepo)
+			NO_GIT_REPO=1
+			;;
+		-ns | --nosubmodule)
+			NO_GIT_SUBMODULES=1
+			;;
+		-pc | --purgeclean)
+			PURGECLEAN=1
+			;;
+	# HANDLING OPTIONS -----------------------
+		# TEMPLATE ARGUMENT --------------
+		-t | --template)
+			TEMPLATE="$2"
+			shift
+			;;
+		--template=?*)
+			TEMPLATE=${1#*=} # Deletes everything up to "=" and assigns the remainder
+			;;
+		# KICADDIR ARGUMENT --------------
+		-kd | --kicaddir)
+			KICADDIR="$2"
+			shift
+			;;
+		--kicaddir=?*)
+			KICADDIR=${1#*=} # Deletes everything up to "=" and assigns the remainder
+			;;
+		# LIBDIR ARGUMENT ----------------
+		-ld | --libdir)
+			LIBDIR="$2"
+			shift
+			;;
+		--libdir=?*)
+			LIBDIR=${1#*=} # Deletes everything up to "=" and assigns the remainder
+			;;
+		# PRJNAME ARGUMENT ----------------
+		-p | --projectname)
+			PRJNAME="$2"
+			shift
+			;;
+		--projectname=?*)
+			PRJNAME=${1#*=} # Deletes everything up to "=" and assigns the remainder
+			;;
+		# SWITCHTYPE ARGUMENT ----------------
+		-s | --switchtype)
+			SWITCHTYPE="$2"
+			shift
+			;;
+		--switchtype=?*)
+			SWITCHTYPE=${1#*=} # Deletes everything up to "=" and assigns the remainder
+			;;
+		*)
+			echo2stderr "${BOLD}${RED}>> WARN: ${RESET} Unknown argument '$1'. Ignoring..."
+	esac
+	shift
+done
+#}}}1
+
+# Check the correctness of the values read from stdin ----------------------------------------- {{{1
+verbose_logging "${BOLD}>> INFO:  ${GREEN}Verbose logging enabled${RESET}"
+verbose_logging "${BOLD}>> DEBUG: ${YELLOW}OUTPUT_REDIRECTION set to ${OUTPUT_REDIRECTION}${RESET}"
+verbose_logging "${BOLD}>> DEBUG: ${YELLOW}CLEANCREATE set to ${CLEANCREATE}${RESET}"
+verbose_logging "${BOLD}>> DEBUG: ${YELLOW}NOLOGOS set to ${NOLOGOS}${RESET}"
+verbose_logging "${BOLD}>> DEBUG: ${YELLOW}NOGRAPHICS set to ${NOGRAPHICS}${RESET}"
+verbose_logging "${BOLD}>> DEBUG: ${YELLOW}NO3D set to ${NO3D}${RESET}"
+verbose_logging "${BOLD}>> DEBUG: ${YELLOW}NO_GIT_REPO set to ${NO_GIT_REPO}${RESET}"
+verbose_logging "${BOLD}>> DEBUG: ${YELLOW}NO_GIT_SUBMODULES set to ${NO_GIT_SUBMODULES}${RESET}"
+verbose_logging "${BOLD}>> DEBUG: ${YELLOW}PURGECLEAN set to ${PURGECLEAN}${RESET}"
+verbose_logging "${BOLD}>> DEBUG: ${YELLOW}TEMPLATE set to ${TEMPLATE}${RESET}"
+verbose_logging "${BOLD}>> DEBUG: ${YELLOW}KICADDIR set to ${KICADDIR}${RESET}"
+verbose_logging "${BOLD}>> DEBUG: ${YELLOW}LIBDIR set to ${LIBDIR}${RESET}"
+verbose_logging "${BOLD}>> DEBUG: ${YELLOW}PRJNAME set to ${PRJNAME}${RESET}"
+verbose_logging "${BOLD}>> DEBUG: ${YELLOW}SWITCHTYPE set to ${SWITCHTYPE}${RESET}"
+
+if [[ -z "${TEMPLATE}" ]]; then
+	echo2stderr "${BOLD}${RED}>> ERROR:${RESET} -t/--template argument requires a non-empty string."
+	exit 1
+fi
+
+if [[ -z "${KICADDIR}" ]]; then
+	echo2stderr "${BOLD}${RED}>> ERROR:${RESET} -kd/--kicaddir argument requires a non-empty string."
+	exit 2
+fi
+
+if [[ -z "${LIBDIR}" ]]; then
+	echo2stderr "${BOLD}${RED}>> ERROR:${RESET} -ld/--libdir argument requires a non-empty string."
+	exit 3
+fi
+
+if [[ -z "${PRJNAME}" ]]; then
+	echo2stderr "${BOLD}${RED}>> ERROR:${RESET} -p/--projectname requires a non-empty string."
+	exit 4
+fi
+#}}}1
+
+# Checking if the limited options are in the allowed values ----------------------------------- {{{1
+if [[ ! ${ALLOWED_SWITCHTYPES[*]} =~ (^|[[:space:]])"${SWITCHTYPE}"($|[[:space:]]) ]]; then
+	echo2stderr "${BOLD}${RED}>> ERROR:${WHITE} switch type option '${SWITCHTYPE}' is not recognized. Run the script with the '-h' option for usage guidelines.${RESET}"
+	exit 5
+fi
+
+if [[ ! ${ALLOWED_TEMPLATES[*]} =~ (^|[[:space:]])"${TEMPLATE}"($|[[:space:]]) ]]; then
+	echo2stderr "${BOLD}${RED}>> ERROR:${WHITE} template option '${TEMPLATE}' is not recognized. Run the script with the '-h' option for usage guidelines.${RESET}"
+	exit 6
+fi
 #}}}1
 
 main "${TEMPLATE}" "${NOGRAPHICS}" "${NOLOGOS}" "${NO3D}" "${CLEANCREATE}" "${NO_GIT_REPO}" "${NO_GIT_SUBMODULES}" "${PURGECLEAN}" "${SWITCHTYPE}"

--- a/keyboard_creator/keyboard_create.sh
+++ b/keyboard_creator/keyboard_create.sh
@@ -15,11 +15,11 @@ RESET=$(tput sgr0); readonly RESET
 #}}}1
 
 # Default commands ------------------------------------------------------------------------- {{{1
-readonly TRASH_COMMAND='/usr/bin/env gio trash'
 readonly CP_COMMAND='/usr/bin/env cp'
 readonly GIT_COMMAND='/usr/bin/env git'
 readonly MKDIR_COMMAND='/usr/bin/env mkdir'
 readonly PERL_COMMAND='/usr/bin/env perl'
+readonly RM_COMMAND='/usr/bin/env rm'
 #}}}1
 
 # Default values -------------------------------------------------------------------------- {{{1
@@ -74,8 +74,8 @@ ${BOLD}Usage: $0 [options] [arguments] (Note: ${GREEN}green${WHITE} values signa
 ${GREEN}>>${WHITE} Options:${RESET}
 	${BOLD}[-h,  --help]${RESET}		Displays this message and exists.
 	${BOLD}[-v,  --verbose]${RESET}	Enable verbose logging.
-	${BOLD}[-pc, --purgeclean]${RESET}	Deletes all generated files before execution (*.git folders and files and the KICADDIR), leaving only the original repository, and proceeds normal execution. ${BOLD}${GREEN}(F)${RESET}
-	${BOLD}[-cc, --cleancreate]${RESET}	Creates cleanly, removing all base files including this script, leaving only the final files. ${BOLD}${GREEN}(F)${RESET}
+	${BOLD}[-pc, --purgeclean]${RESET}	Deletes all generated files before execution (*.git folders and files and the KICADDIR), leaving only the original repository, and proceeds normal execution. ${BOLD}${RED} WARNING: deletions are definitive! ${GREEN}(F)${RESET}
+	${BOLD}[-cc, --cleancreate]${RESET}	Creates cleanly, removing all base files including this script, leaving only the final files. ${BOLD}${RED} WARNING: deletions are definitive! ${GREEN}(F)${RESET}
 	${BOLD}[-ng, --nographics]${RESET}	Do not include graphics library submodule. ${BOLD}${GREEN}(F)${RESET}
 	${BOLD}[-nl, --nologos]${RESET}	Do not include logos library submodule. ${BOLD}${GREEN}(F)${RESET}
 	${BOLD}[-n3, --no3d]${RESET}		Do not include 3D models library submodule. ${BOLD}${GREEN}(F)${RESET}
@@ -373,7 +373,7 @@ add_library() {
 # This function deletes all *.git files and folders, also the ${KICADDIR}.
 clean(){
 	echo2stdout -e "${YELLOW}${BOLD}>> CLEANING${WHITE} produced files... \c"
-	${TRASH_COMMAND} ./.git ./.gitmodules ./"${KICADDIR}" > /dev/null 2>&1
+	${RM_COMMAND} -rf ./.git ./.gitmodules "./${KICADDIR}" > /dev/null 2>&1
 	echo2stdout -e "${BOLD}${GREEN}Done.${RESET}"
 }
 #}}}1
@@ -426,7 +426,7 @@ main(){
 
 	if [[ "${LOCAL_CLEANCREATE}" -eq 1 ]]; then
 		echo2stdout -e "${BOLD}${YELLOW}>>${WHITE} Cleaning up... ${RESET}\c"
-		${TRASH_COMMAND} ./keyboard_create.sh ./*_template > /dev/null 2>&1
+		${RM_COMMAND} -rf ./keyboard_create.sh ./*_template > /dev/null 2>&1
 		echo2stdout "${BOLD}${GREEN} Done.${RESET}"
 	fi
 

--- a/keyboard_creator/keyboard_create.sh
+++ b/keyboard_creator/keyboard_create.sh
@@ -299,7 +299,7 @@ main(){
 	fi
 
 	if [[ "${NO3D}" -eq 0 ]]; then
-		if add_library acheron_3D "${NO_GIT_SUBMODULE}"; then exit 16; fi
+		if add_git_library acheron_3D "${NO_GIT_SUBMODULE}"; then exit 16; fi
 	fi
 
 	if [[ "${LOCAL_CLEANCREATE}" -eq 1 ]]; then

--- a/keyboard_creator/keyboard_create.sh
+++ b/keyboard_creator/keyboard_create.sh
@@ -147,21 +147,21 @@ kicad_setup() {
 }
 #}}}1
 
-# git_add_library function ----------------------- {{{1
-# The git_add_library function does exactly that: adds a library to the project from a git repository.
+# add_git_library function ----------------------- {{{1
+# The add_git_library function does exactly that: adds a library to the project from a git repository.
 # However, this can be done in two ways: either as a git submodule or simply cloning the library from its repository; the behavior depends on the NO_GIT_SUBMODULES flag set when the script is called.
-git_add_library() {
+add_git_library() {
 	local TARGET_LIBRARY="$1"
 	local NO_GIT_SUBMODULES="$2"
 	local TARGET_LIBRARY_GIT_REPO_URL="${ACRNPRJ_REPO}/${TARGET_LIBRARY}.git"
 	local exit_code=
 
 	if [[ -z "${TARGET_LIBRARY}" ]]; then
-		echo2stderr "${RED}${BOLD}>> ERROR${WHITE} on function git_add_library():${RESET} no argument passed."
+		echo2stderr "${RED}${BOLD}>> ERROR${WHITE} on function add_git_library():${RESET} no argument passed."
 		return 0
 	fi
 	if [[ -z "${NO_GIT_SUBMODULES}" ]]; then
-		echo2stderr "${RED}${BOLD}>> ERROR${WHITE} on function git_add_library():${RESET} not enough arguments passed (2 required, only 1 passed)."
+		echo2stderr "${RED}${BOLD}>> ERROR${WHITE} on function add_git_library():${RESET} not enough arguments passed (2 required, only 1 passed)."
 		return 0
 	fi
 
@@ -176,7 +176,7 @@ git_add_library() {
 	fi
 
 	if [[ ${exit_code} -ne 0 ]]; then
-		echo2stderr "${RED}${BOLD}>> ERROR${WHITE} on function git_add_library():${RESET} an error occured when trying to clone ${TARGET_LIBRARY_GIT_REPO_URL}."
+		echo2stderr "${RED}${BOLD}>> ERROR${WHITE} on function add_git_library():${RESET} an error occured when trying to clone ${TARGET_LIBRARY_GIT_REPO_URL}."
 		return 0
 	fi
 
@@ -206,7 +206,7 @@ add_line_in_file() {
 #}}}1
 
 # add_library function ----------------------- {{{1
-# This function calls the git_add_library and add_line_in_file functions. First, it adds the library from the the git repository, then depending on the IS_FOOTPRINT variable, it adds the library to KiCAD's library tables "sym-lib-table" and "fp-lib-table".
+# This function calls the add_git_library and add_line_in_file functions. First, it adds the library from the the git repository, then depending on the IS_FOOTPRINT variable, it adds the library to KiCAD's library tables "sym-lib-table" and "fp-lib-table".
 # It must be noted that these two files should not be created from scratch as they have a header and a footer; hence, the template folders contain unedited, blank version of these files.
 add_library() {
 	local LIBRARY="$1"
@@ -229,7 +229,7 @@ add_library() {
 
 	local LINE="	(lib (name \"${LIBRARY%.pretty}\")(type \"KiCad\")(uri \"\${KIPRJMOD}/${PATH_TO_LIBRARY}\")(options \"\")(descr \"Acheron Project ${LIBRARY_TYPE} library\"))"
 
-	git_add_library "${LIBRARY}" "${NO_GIT_SUBMODULES}"
+	add_git_library "${LIBRARY}" "${NO_GIT_SUBMODULES}"
 	return_code=$?
 
 	if [[ ${return_code} -eq 1 ]]; then

--- a/keyboard_creator/keyboard_create.sh
+++ b/keyboard_creator/keyboard_create.sh
@@ -388,7 +388,7 @@ main(){
 	fi
 
 	if [[ "${NOLOGOS}" -eq 0 ]]; then
-		if add_footprintlib acheron_Logo.pretty "${NO_GIT_SUBMODULE}"; then exit 15; fi
+		if add_footprintlib acheron_Logos.pretty "${NO_GIT_SUBMODULE}"; then exit 15; fi
 	fi
 
 	if [[ "${NO3D}" -eq 0 ]]; then

--- a/keyboard_creator/keyboard_create.sh
+++ b/keyboard_creator/keyboard_create.sh
@@ -30,6 +30,7 @@ readonly ALLOWED_SWITCHTYPES=(MX MX_soldermask MXA MXH)
 readonly ALLOWED_TEMPLATES=(BLANK J48 J64)
 
 VERBOSE=0
+OUTPUT_REDIRECTION='&>/dev/null'
 NOGRAPHICS=0
 NO3D=0
 NOLOGOS=0
@@ -108,6 +109,7 @@ while (( "$#" )); do
 			;;
 		-v | --verbose)
 			VERBOSE=1
+			OUTPUT_REDIRECTION=
 			;;
 		-cc | --cleancreate)
 			CLEANCREATE=1
@@ -180,6 +182,7 @@ done
 
 # Check the correctness of the values read from stdin ----------------------------------------- {{{1
 verbose_logging "${BOLD}>> INFO:  ${GREEN}Verbose logging enabled${RESET}"
+verbose_logging "${BOLD}>> DEBUG: ${YELLOW}OUTPUT_REDIRECTION set to ${OUTPUT_REDIRECTION}${RESET}"
 verbose_logging "${BOLD}>> DEBUG: ${YELLOW}CLEANCREATE set to ${CLEANCREATE}${RESET}"
 verbose_logging "${BOLD}>> DEBUG: ${YELLOW}NOLOGOS set to ${NOLOGOS}${RESET}"
 verbose_logging "${BOLD}>> DEBUG: ${YELLOW}NOGRAPHICS set to ${NOGRAPHICS}${RESET}"
@@ -235,7 +238,7 @@ kicad_setup() {
 	local TEMPLATE_FILENAME='blank'
 
 	if [[ -z "${TEMPLATE_NAME}" ]]; then
-		echo2stderr "${RED}${BOLD}>> ERROR${WHITE} on function kicad_setup:${RESET} no argument passed."
+		echo2stderr "${RED}${BOLD}>> ERROR${WHITE} on function kicad_setup():${RESET} no argument passed."
 		return 0
 	fi
 
@@ -251,27 +254,27 @@ kicad_setup() {
 			TEMPLATE_FILENAME='joker64'
 			;;
 		*)
-			echo2stderr "${RED}${BOLD}>> ERROR${WHITE} on function kicad_setup:${RESET} TEMPLATE_NAME option '${TEMPLATE_NAME}' unrecognized."
+			echo2stderr "${RED}${BOLD}>> ERROR${WHITE} on function kicad_setup():${RESET} TEMPLATE_NAME option '${TEMPLATE_NAME}' unrecognized."
 			return 0
 	esac
 
 	if [[ ! -d "${KICADDIR}" ]]; then
 		echo2stdout -e "${BOLD}${RED}>> KiCAD directory at ${KICADDIR} not found, Libraries directory at ${KICADDIR}/${LIBDIR} not found.${WHITE} Creating them...${RESET} \c"
-		${MKDIR_COMMAND} -p "${KICADDIR}/${LIBDIR}"
+		eval "${MKDIR_COMMAND}" -vp "${KICADDIR}/${LIBDIR}" "${OUTPUT_REDIRECTION}"
 		echo2stdout " ${BOLD}${GREEN}Done.${RESET}"
 	elif [[ ! -d "${KICADDIR}/${LIBDIR}" ]]; then
 		echo2stdout -e "${BOLD}${GREEN}>> KiCAD directory found at ${KICADDIR}.${RESET}" ;
 		echo2stdout -e "${BOLD}${RED}>> Libraries directory at ${KICADDIR}/${LIBDIR} not found.${WHITE} Creating it...${RESET} \c"
-		${MKDIR_COMMAND} "${KICADDIR}/${LIBDIR}"
+		eval "${MKDIR_COMMAND}" -v "${KICADDIR}/${LIBDIR}" "${OUTPUT_REDIRECTION}"
 		echo2stdout "${BOLD}${GREEN}Done.${RESET}"
 	fi
 
-	${CP_COMMAND} "${TEMPLATE_DIR}/${TEMPLATE_FILENAME}.kicad_pro" "${KICADDIR}/${PRJNAME}.kicad_pro"
-	${CP_COMMAND} "${TEMPLATE_DIR}/${TEMPLATE_FILENAME}.kicad_pcb" "${KICADDIR}/${PRJNAME}.kicad_pcb"
-	${CP_COMMAND} "${TEMPLATE_DIR}/${TEMPLATE_FILENAME}.kicad_prl" "${KICADDIR}/${PRJNAME}.kicad_prl"
-	${CP_COMMAND} "${TEMPLATE_DIR}/${TEMPLATE_FILENAME}.kicad_sch" "${KICADDIR}/${PRJNAME}.kicad_sch"
-	${CP_COMMAND} "${TEMPLATE_DIR}/sym-lib-table" "${KICADDIR}/sym-lib-table"
-	${CP_COMMAND} "${TEMPLATE_DIR}/fp-lib-table" "${KICADDIR}/fp-lib-table"
+	eval "${CP_COMMAND}" -v "${TEMPLATE_DIR}/${TEMPLATE_FILENAME}.kicad_pro" "${KICADDIR}/${PRJNAME}.kicad_pro" "${OUTPUT_REDIRECTION}"
+	eval "${CP_COMMAND}" -v "${TEMPLATE_DIR}/${TEMPLATE_FILENAME}.kicad_pcb" "${KICADDIR}/${PRJNAME}.kicad_pcb" "${OUTPUT_REDIRECTION}"
+	eval "${CP_COMMAND}" -v "${TEMPLATE_DIR}/${TEMPLATE_FILENAME}.kicad_prl" "${KICADDIR}/${PRJNAME}.kicad_prl" "${OUTPUT_REDIRECTION}"
+	eval "${CP_COMMAND}" -v "${TEMPLATE_DIR}/${TEMPLATE_FILENAME}.kicad_sch" "${KICADDIR}/${PRJNAME}.kicad_sch" "${OUTPUT_REDIRECTION}"
+	eval "${CP_COMMAND}" -v "${TEMPLATE_DIR}/sym-lib-table" "${KICADDIR}/sym-lib-table" "${OUTPUT_REDIRECTION}"
+	eval "${CP_COMMAND}" -v "${TEMPLATE_DIR}/fp-lib-table" "${KICADDIR}/fp-lib-table" "${OUTPUT_REDIRECTION}"
 
 	return 1
 }
@@ -296,11 +299,11 @@ git_add_library() {
 
 	 if [[ "${NO_GIT_SUBMODULES}" -eq 0 ]]; then
 		echo2stdout -e "${BOLD}>> Adding ${MAGENTA}${TARGET_LIBRARY}${WHITE} library as a submodule from ${BLUE}${BOLD}${TARGET_LIBRARY_GIT_REPO_URL}${RESET} at ${RED}${BOLD}\"${KICADDIR}/${LIBDIR}/${TARGET_LIBRARY}\"${RESET} folder... \c"
-		${GIT_COMMAND} submodule add "${TARGET_LIBRARY_GIT_REPO_URL}" "${KICADDIR}/${LIBDIR}/${TARGET_LIBRARY}" > /dev/null 2>&1
+		eval "${GIT_COMMAND}" submodule add "${TARGET_LIBRARY_GIT_REPO_URL}" "${KICADDIR}/${LIBDIR}/${TARGET_LIBRARY}" "${OUTPUT_REDIRECTION}"
 		exit_code=$?
 	else
 		echo2stdout -e "${BOLD}>> Cloning ${MAGENTA}${TARGET_LIBRARY}${WHITE} library from ${BLUE}${BOLD}${TARGET_LIBRARY_GIT_REPO_URL}${RESET} at ${RED}${BOLD}\"${KICADDIR}/${LIBDIR}/${TARGET_LIBRARY}\"${RESET} folder... \c"
-		${GIT_COMMAND} clone "${TARGET_LIBRARY_GIT_REPO_URL}" "${KICADDIR}/${LIBDIR}/${TARGET_LIBRARY}" > /dev/null 2>&1
+		eval "${GIT_COMMAND}" clone "${TARGET_LIBRARY_GIT_REPO_URL}" "${KICADDIR}/${LIBDIR}/${TARGET_LIBRARY}" "${OUTPUT_REDIRECTION}"
 		exit_code=$?
 	fi
 
@@ -320,7 +323,7 @@ add_line_in_file() {
 	local PERL_ARGS="-i -l -p -e"
 	local exit_code=
 
-	${PERL_COMMAND} ${PERL_ARGS} "print '${LINE}' if $. == ${LINE_NUMBER}" "${TARGET_FILE}" > /dev/null
+	eval "${PERL_COMMAND}" "${PERL_ARGS}" "'print '\''${LINE}'\'' if $. == ${LINE_NUMBER}'" "${TARGET_FILE}" "${OUTPUT_REDIRECTION}"
 	exit_code=$?  # exit_code = 0 if the perl command was successfully executed
 
 	if [[ ${exit_code} -ne 0 ]]; then
@@ -373,7 +376,7 @@ add_library() {
 # This function deletes all *.git files and folders, also the ${KICADDIR}.
 clean(){
 	echo2stdout -e "${YELLOW}${BOLD}>> CLEANING${WHITE} produced files... \c"
-	${RM_COMMAND} -rf ./.git ./.gitmodules "./${KICADDIR}" > /dev/null 2>&1
+	eval "${RM_COMMAND}" -rfv ./.git ./.gitmodules "./${KICADDIR}" "${OUTPUT_REDIRECTION}"
 	echo2stdout -e "${BOLD}${GREEN}Done.${RESET}"
 }
 #}}}1
@@ -398,8 +401,8 @@ main(){
 	if [[ "${PURGECLEAN}" -eq 1 ]]; then clean; fi
 	if [[ "${NO_GIT_REPO}" -eq 0 ]]; then
 		echo2stdout -e "${BOLD}${GREEN}>>${WHITE} Initializing git repo... \c"
-		${GIT_COMMAND} init > /dev/null 2>&1
-		${GIT_COMMAND} branch -M main
+		eval "${GIT_COMMAND}" init "${OUTPUT_REDIRECTION}"
+		eval "${GIT_COMMAND}" branch -M main "${OUTPUT_REDIRECTION}"
 		echo2stdout "${BOLD}${GREEN}Done.${RESET}"
 	fi
 
@@ -426,7 +429,7 @@ main(){
 
 	if [[ "${LOCAL_CLEANCREATE}" -eq 1 ]]; then
 		echo2stdout -e "${BOLD}${YELLOW}>>${WHITE} Cleaning up... ${RESET}\c"
-		${RM_COMMAND} -rf ./keyboard_create.sh ./*_template > /dev/null 2>&1
+		eval "${RM_COMMAND}" -rfv ./keyboard_create.sh ./*_template "${OUTPUT_REDIRECTION}"
 		echo2stdout "${BOLD}${GREEN} Done.${RESET}"
 	fi
 

--- a/keyboard_creator/keyboard_create.sh
+++ b/keyboard_creator/keyboard_create.sh
@@ -47,7 +47,7 @@ TEMPLATE='BLANK'
 function echo_text() {
 	local text_to_print="${*:$#}"  # Assuming it's the last parameter
 	local echo_args="${*%"${!#}"}" # Assuming it's the rest
-	echo ${echo_args} "${text_to_print}" >&1
+	echo ${echo_args} "${text_to_print}"
 }
 
 function echo2stdout() {

--- a/keyboard_creator/keyboard_create.sh
+++ b/keyboard_creator/keyboard_create.sh
@@ -44,20 +44,17 @@ TEMPLATE='BLANK'
 #}}}1
 
 # Printing functions ----------------------------------------------------------------------------- {{{1
-function echo_text() {
-	local TEXT_TO_PRINT="${*:$#}"  # Assuming it's the last parameter
-	local ECHO_ARGS="${*%"${!#}"}" # Assuming it's the rest
-	echo ${ECHO_ARGS} "${TEXT_TO_PRINT}"
-}
-
+# Prints to STDOUT
 function echo2stdout() {
-	echo_text "$@" >&1
+	echo "$@" >&1
 }
 
+# Prints to STDOUT
 function echo2stderr() {
-	echo_text "$@" >&2
+	echo "$@" >&2
 }
 
+# Prints to STDOUT if verbose mode is enabled
 function verbose_logging() {
 	[[ "${VERBOSE}" -eq 1 ]] && echo2stdout "$@"
 }

--- a/keyboard_creator/keyboard_create.sh
+++ b/keyboard_creator/keyboard_create.sh
@@ -28,6 +28,7 @@ readonly KICADDIR='kicad_files'
 readonly ACRNPRJ_REPO='git@github.com:AcheronProject'
 readonly ALLOWED_SWITCHTYPES=(MX MX_soldermask MXA MXH)
 readonly ALLOWED_TEMPLATES=(BLANK J48 J64)
+readonly SED_BACKUP_EXT='.bak'
 
 VERBOSE=0
 NOGRAPHICS=0
@@ -315,9 +316,10 @@ add_symlib() {
 
 	if [[ ${rc} -ne 0 ]]; then
 		echo2stdout -e "${BOLD}>> Adding ${MAGENTA}${SYMBOLS_LIBRARY}${WHITE} symbol library to KiCAD library table... \c"
-		${SED_COMMAND} -i'' -e "2i\\
+		${SED_COMMAND} -i${SED_BACKUP_EXT} -e "2i\\
 (lib (name \"${SYMBOLS_LIBRARY}\")(type \"KiCad\")(uri \"\\\$\{KIPRJMOD\}\/${LIBDIR}/${SYMBOLS_LIBRARY}/${SYMBOLS_LIBRARY}.kicad_sym\")(options \"\")(descr \"Acheron Project symbol library\"))
 " "${KICADDIR}/sym-lib-table" > /dev/null
+		${TRASH_COMMAND} "${KICADDIR}/sym-lib-table${SED_BACKUP_EXT}"
 		echo2stdout "${BOLD}${GREEN}Done.${RESET}"
 	fi
 
@@ -334,9 +336,10 @@ add_footprintlib(){
 
 	if [[ ${rc} -ne 0 ]]; then
 		echo2stdout -e "${BOLD}>> Adding ${MAGENTA}${FOOTPRINTS_LIBRARY}${WHITE} footprint library to KiCAD library table... \c"
-		${SED_COMMAND} -i'' -e "2i\\
+		${SED_COMMAND} -i${SED_BACKUP_EXT} -e "2i\\
 (lib (name \"${FOOTPRINTS_LIBRARY}\")(type \"KiCad\")(uri \"\\\$\{KIPRJMOD\}/${LIBDIR}/${FOOTPRINTS_LIBRARY}.pretty\")(options \"\")(descr \"Acheron Project footprint library\"))
 " "${KICADDIR}/fp-lib-table" > /dev/null
+		${TRASH_COMMAND} "${KICADDIR}/fp-lib-table${SED_BACKUP_EXT}"
 		echo2stdout "${BOLD}${GREEN}Done.${RESET}"
 	fi
 

--- a/keyboard_creator/keyboard_create.sh
+++ b/keyboard_creator/keyboard_create.sh
@@ -19,7 +19,7 @@ readonly TRASH_COMMAND='/usr/bin/env gio trash'
 readonly CP_COMMAND='/usr/bin/env cp'
 readonly GIT_COMMAND='/usr/bin/env git'
 readonly MKDIR_COMMAND='/usr/bin/env mkdir'
-readonly SED_COMMAND='/usr/bin/env sed'
+readonly PERL_COMMAND='/usr/bin/env perl'
 #}}}1
 
 # Default values -------------------------------------------------------------------------- {{{1
@@ -28,7 +28,6 @@ readonly KICADDIR='kicad_files'
 readonly ACRNPRJ_REPO='git@github.com:AcheronProject'
 readonly ALLOWED_SWITCHTYPES=(MX MX_soldermask MXA MXH)
 readonly ALLOWED_TEMPLATES=(BLANK J48 J64)
-readonly SED_BACKUP_EXT='.bak'
 
 VERBOSE=0
 NOGRAPHICS=0
@@ -316,10 +315,7 @@ add_symlib() {
 
 	if [[ ${rc} -ne 0 ]]; then
 		echo2stdout -e "${BOLD}>> Adding ${MAGENTA}${SYMBOLS_LIBRARY}${WHITE} symbol library to KiCAD library table... \c"
-		${SED_COMMAND} -i${SED_BACKUP_EXT} -e "2i\\
-(lib (name \"${SYMBOLS_LIBRARY}\")(type \"KiCad\")(uri \"\${KIPRJMOD}/${LIBDIR}/${SYMBOLS_LIBRARY}/${SYMBOLS_LIBRARY}.kicad_sym\")(options \"\")(descr \"Acheron Project symbol library\"))
-" "${KICADDIR}/sym-lib-table" > /dev/null
-		${TRASH_COMMAND} "${KICADDIR}/sym-lib-table${SED_BACKUP_EXT}"
+		${PERL_COMMAND} -i -l -p -e "print '	(lib (name \"${SYMBOLS_LIBRARY}\")(type \"KiCad\")(uri \"\${KIPRJMOD}/${LIBDIR}/${SYMBOLS_LIBRARY}/${SYMBOLS_LIBRARY}.kicad_sym\")(options \"\")(descr \"Acheron Project symbol library\"))' if $. == 2" "${KICADDIR}/sym-lib-table" > /dev/null
 		echo2stdout "${BOLD}${GREEN}Done.${RESET}"
 	fi
 
@@ -336,10 +332,7 @@ add_footprintlib(){
 
 	if [[ ${rc} -ne 0 ]]; then
 		echo2stdout -e "${BOLD}>> Adding ${MAGENTA}${FOOTPRINTS_LIBRARY}${WHITE} footprint library to KiCAD library table... \c"
-		${SED_COMMAND} -i${SED_BACKUP_EXT} -e "2i\\
-(lib (name \"${FOOTPRINTS_LIBRARY}\")(type \"KiCad\")(uri \"\${KIPRJMOD}/${LIBDIR}/${FOOTPRINTS_LIBRARY}.pretty\")(options \"\")(descr \"Acheron Project footprint library\"))
-" "${KICADDIR}/fp-lib-table" > /dev/null
-		${TRASH_COMMAND} "${KICADDIR}/fp-lib-table${SED_BACKUP_EXT}"
+		${PERL_COMMAND} -i -l -p -e "print '	(lib (name \"${FOOTPRINTS_LIBRARY}\")(type \"KiCad\")(uri \"\${KIPRJMOD}/${LIBDIR}/${FOOTPRINTS_LIBRARY}.pretty\")(options \"\")(descr \"Acheron Project symbol library\"))' if $. == 2" "${KICADDIR}/fp-lib-table" > /dev/null
 		echo2stdout "${BOLD}${GREEN}Done.${RESET}"
 	fi
 

--- a/keyboard_creator/keyboard_create.sh
+++ b/keyboard_creator/keyboard_create.sh
@@ -128,7 +128,7 @@ kicad_setup() {
 	if [[ ! -d "${KICADDIR}" ]]; then
 		echo2stdout -e "${BOLD}${RED}>> KiCAD directory at ${KICADDIR} not found, Libraries directory at ${KICADDIR}/${LIBDIR} not found.${WHITE} Creating them...${RESET} \c"
 		eval "${MKDIR_COMMAND}" -vp "${KICADDIR}/${LIBDIR}" "${OUTPUT_REDIRECTION}"
-		echo2stdout " ${BOLD}${GREEN}Done.${RESET}"
+		echo2stdout "${BOLD}${GREEN}Done.${RESET}"
 	elif [[ ! -d "${KICADDIR}/${LIBDIR}" ]]; then
 		echo2stdout -e "${BOLD}${GREEN}>> KiCAD directory found at ${KICADDIR}.${RESET}" ;
 		echo2stdout -e "${BOLD}${RED}>> Libraries directory at ${KICADDIR}/${LIBDIR} not found.${WHITE} Creating it...${RESET} \c"
@@ -305,7 +305,7 @@ main(){
 	if [[ "${LOCAL_CLEANCREATE}" -eq 1 ]]; then
 		echo2stdout -e "${BOLD}${YELLOW}>>${WHITE} Cleaning up... ${RESET}\c"
 		eval "${RM_COMMAND}" -rfv ./keyboard_create.sh ./*_template "${OUTPUT_REDIRECTION}"
-		echo2stdout "${BOLD}${GREEN} Done.${RESET}"
+		echo2stdout "${BOLD}${GREEN}Done.${RESET}"
 	fi
 
 	exit 0

--- a/keyboard_creator/keyboard_create.sh
+++ b/keyboard_creator/keyboard_create.sh
@@ -351,7 +351,7 @@ add_footprintlib(){
 # This function deletes all *.git files and folders, also the ${KICADDIR}.
 clean(){
 	echo2stdout -e "${YELLOW}${BOLD}>> CLEANING${WHITE} produced files... \c"
-	${TRASH_COMMAND} .git .gitmodules "${KICADDIR}" > /dev/null 2>&1
+	${TRASH_COMMAND} ./.git ./.gitmodules ./"${KICADDIR}" > /dev/null 2>&1
 	echo2stdout -e "${BOLD}${GREEN}Done.${RESET}"
 }
 #}}}1
@@ -404,7 +404,7 @@ main(){
 
 	if [[ "${LOCAL_CLEANCREATE}" -eq 1 ]]; then
 		echo2stdout -e "${BOLD}${YELLOW}>>${WHITE} Cleaning up... ${RESET}\c"
-		${TRASH_COMMAND} keyboard_create.sh *_template
+		${TRASH_COMMAND} ./keyboard_create.sh ./*_template > /dev/null 2>&1
 		echo2stdout "${BOLD}${GREEN} Done.${RESET}"
 	fi
 

--- a/keyboard_creator/keyboard_create.sh
+++ b/keyboard_creator/keyboard_create.sh
@@ -318,9 +318,10 @@ add_line_in_file() {
 	local LINE="$1"
 	local TARGET_FILE="$2"
 	local LINE_NUMBER=${3:-2} # Default line number is 2
+	local PERL_ARGS="-i -l -p -e"
 	local rc=
 
-	${PERL_COMMAND} -i -l -p -e "print '${LINE}' if $. == ${LINE_NUMBER}" "${TARGET_FILE}" > /dev/null
+	${PERL_COMMAND} ${PERL_ARGS} "print '${LINE}' if $. == ${LINE_NUMBER}" "${TARGET_FILE}" > /dev/null
 	rc=$?  # rc = 0 if the perl command was successfully executed
 
 	if [[ ${rc} -ne 0 ]]; then

--- a/keyboard_creator/keyboard_create.sh
+++ b/keyboard_creator/keyboard_create.sh
@@ -323,7 +323,7 @@ add_symlib() {
 }
 
 add_footprintlib(){
-	local FOOTPRINTS_LIBRARY="$1.pretty"
+	local FOOTPRINTS_LIBRARY="$1"
 	local NO_GIT_SUBMODULES="$2"
 	local rc=
 
@@ -332,7 +332,7 @@ add_footprintlib(){
 
 	if [[ ${rc} -ne 0 ]]; then
 		echo2stdout -e "${BOLD}>> Adding ${MAGENTA}${FOOTPRINTS_LIBRARY}${WHITE} footprint library to KiCAD library table... \c"
-		${PERL_COMMAND} -i -l -p -e "print '	(lib (name \"${FOOTPRINTS_LIBRARY}\")(type \"KiCad\")(uri \"\${KIPRJMOD}/${LIBDIR}/${FOOTPRINTS_LIBRARY}.pretty\")(options \"\")(descr \"Acheron Project symbol library\"))' if $. == 2" "${KICADDIR}/fp-lib-table" > /dev/null
+		${PERL_COMMAND} -i -l -p -e "print '	(lib (name \"${FOOTPRINTS_LIBRARY%.pretty}\")(type \"KiCad\")(uri \"\${KIPRJMOD}/${LIBDIR}/${FOOTPRINTS_LIBRARY}\")(options \"\")(descr \"Acheron Project symbol library\"))' if $. == 2" "${KICADDIR}/fp-lib-table" > /dev/null
 		echo2stdout "${BOLD}${GREEN}Done.${RESET}"
 	fi
 
@@ -378,17 +378,17 @@ main(){
 
 	if add_symlib acheron_Symbols "${NO_GIT_SUBMODULE}"; then exit 9; fi
 
-	if add_footprintlib acheron_Components "${NO_GIT_SUBMODULE}"; then exit 10; fi
-	if add_footprintlib acheron_Connectors "${NO_GIT_SUBMODULE}"; then exit 11; fi
-	if add_footprintlib acheron_Hardware "${NO_GIT_SUBMODULE}"; then exit 12; fi
-	if add_footprintlib "acheron_${SWITCHTYPE}" "${NO_GIT_SUBMODULE}"; then exit 13; fi
+	if add_footprintlib acheron_Components.pretty "${NO_GIT_SUBMODULE}"; then exit 10; fi
+	if add_footprintlib acheron_Connectors.pretty "${NO_GIT_SUBMODULE}"; then exit 11; fi
+	if add_footprintlib acheron_Hardware.pretty "${NO_GIT_SUBMODULE}"; then exit 12; fi
+	if add_footprintlib "acheron_${SWITCHTYPE}.pretty" "${NO_GIT_SUBMODULE}"; then exit 13; fi
 
 	if [[ "${NOGRAPHICS}" -eq 0 ]]; then
-		if add_footprintlib acheron_Graphics "${NO_GIT_SUBMODULE}"; then exit 14; fi
+		if add_footprintlib acheron_Graphics.pretty "${NO_GIT_SUBMODULE}"; then exit 14; fi
 	fi
 
 	if [[ "${NOLOGOS}" -eq 0 ]]; then
-		if add_footprintlib acheron_Logo "${NO_GIT_SUBMODULE}"; then exit 15; fi
+		if add_footprintlib acheron_Logo.pretty "${NO_GIT_SUBMODULE}"; then exit 15; fi
 	fi
 
 	if [[ "${NO3D}" -eq 0 ]]; then


### PR DESCRIPTION
@Gondolindrim: I've taken the liberty to create this new PR with the changes included in https://github.com/AcheronProject/AcheronSetup/pull/5 and https://github.com/AcheronProject/AcheronSetup/pull/7 (and more) to avoid dealing with merge conflicts and rebasing.

The full list of changes introduced in this PR is the following:
- Change inline editing of tables from SED to PERL
- Fixed the issue with the footprints library names (https://github.com/AcheronProject/AcheronSetup/issues/6)
- Fixed a typo in the name of the logos footprint library (https://github.com/AcheronProject/AcheronSetup/issues/6)
- Renamed add_library function to git_add_library
- Extract the line inserting code into a separate function add_line_in_file
- Combined add_footprintlib & add_library into a more generic function
- Replaced the use of 'gio' with 'rm' and added disclaimer to the usage text
- Show external command stdout and stderr if verbose mode is enabled
- Updated the documentation

I noticed that the `acheron_3D`(https://github.com/AcheronProject/acheron_3D) isn't really a footprint library but rather a repository for 3D models used by other footprints in`acheron_*.pretty` libraries.
Because of this, I think that the `acheron_3D` folder shouldn't be added to the `fp-lib-table` file.

**_PS:_** 
This might not be the best place to discuss this, but I believe that for the sake portability and maintainability, the `acheron_3D` should be split across the other footprint libraries and each 3D model used by a footprint should belong in its footprint library under, say a `3d_model` folder.
The goal here is to remove any dependencies from the footprint libraries.

This way, the footprint libraries would only have the 3D models used by its footprints and the 3D models would be available out-of-the-box in KiCad without having the user download any extra repositories/libraries.
